### PR TITLE
Making aws profile optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ terraform\.tfvars
 terraform\.tfstate*
 terraform.tf
 venv/
+.idea


### PR DESCRIPTION
Because build is done by Bamboo agent which doesn't have aws profile

This PR is to fix this error:
```
Error: Error running command 'aws lambda invoke --function-name arn:aws:lambda:us-west-2:xxxxxxx:function:ghrcectest_db_deploy --profile default --region us-west-2 'invoke-response.out'': exit status 255. Output: 
The config profile (default) could not be found
```