### PR TITLE
Add required_providers in main.tf to set provider versions.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,13 @@ locals {
   }
 }
 
+terraform {
+  required_providers {
+    aws  = ">= 2.31.0"
+    null = "~> 2.1"
+  }
+}
+
 resource "aws_security_group" "vpc-postgres-ingress-all-egress" {
   name   = "${var.prefix}-vpc-ingress-all-egress"
   vpc_id = var.vpc_id


### PR DESCRIPTION
We've run into issues deploying from multiple machines - deploying from a machine with a newer version of the aws provider makes deploying from another machine (with the older version) difficult. This PR is meant to address that issue. I chose these versions because they are the versions that Cumulus is currently using.